### PR TITLE
added names_simple option to BEDMatrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: BEDMatrix
-Version: 1.4.1
+Version: 1.4.2
 License: MIT + file LICENSE
 Title: Extract Genotypes from a PLINK .bed File
 Description: A matrix-like data structure that allows for efficient,
@@ -27,6 +27,6 @@ Suggests:
     data.table,
     testthat,
     covr
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# BEDMatrix 1.4.2
+
+* Add `names_simple` option to BEDMatrix initialization function (contributed by Alex Ochoa).
+
+
 # BEDMatrix 1.4.1
 
 * Specify fileset name in messages during instantiation.

--- a/R/BEDMatrix.R
+++ b/R/BEDMatrix.R
@@ -1,7 +1,7 @@
 # Delimiters used in PED files
 delims <- "[ \t]"
 
-initialize <- function(.Object, path, n = NULL, p = NULL) {
+initialize <- function(.Object, path, n = NULL, p = NULL, names_simple=FALSE) {
     path <- path.expand(path)
     if (!file.exists(path)) {
         # Try to add extension (common in PLINK)
@@ -24,16 +24,27 @@ initialize <- function(.Object, path, n = NULL, p = NULL) {
                 # Determine n
                 n <- nrow(fam)
                 # Determine rownames
-                rownames <- paste0(fam[, 1L], "_", fam[, 2L])
+                if (names_simple) {
+                    rownames <- fam[, 2L] # use subject ID only
+                } else {
+                    rownames <- paste0(fam[, 1L], "_", fam[, 2L])
+                }
             } else {
                 fam <- readLines(famPath)
                 # Determine n
                 n <- length(fam)
                 # Determine rownames
-                rownames <- sapply(strsplit(fam, delims), function(line) {
-                    # Concatenate family ID and subject ID
-                    return(paste0(line[1L], "_", line[2L]))
-                })
+                if (names_simple) {
+                    rownames <- sapply(strsplit(fam, delims), function(line) {
+                        # use subject ID only
+                        return(line[2L])
+                    })
+                } else {
+                    rownames <- sapply(strsplit(fam, delims), function(line) {
+                        # Concatenate family ID and subject ID
+                        return(paste0(line[1L], "_", line[2L]))
+                    })
+                }
             }
         }
     } else {
@@ -52,16 +63,27 @@ initialize <- function(.Object, path, n = NULL, p = NULL) {
                 # Determine p
                 p <- nrow(bim)
                 # Determine colnames
-                colnames <- paste0(bim[, 1L], "_", bim[, 2L])
+                if (names_simple) {
+                    colnames <- bim[, 1L] # use SNP name only
+                } else {
+                    colnames <- paste0(bim[, 1L], "_", bim[, 2L])
+                }
             } else {
                 bim <- readLines(bimPath)
                 # Determine p
                 p <- length(bim)
                 # Determine colnames
-                colnames <- sapply(strsplit(bim, delims), function(line) {
-                    # Concatenate SNP name and minor allele (like --recodeA)
-                    return(paste0(line[2L], "_", line[5L]))
-                })
+                if (names_simple) {
+                    colnames <- sapply(strsplit(bim, delims), function(line) {
+                        # use SNP name only
+                        return(line[2L])
+                    })
+                } else {
+                    colnames <- sapply(strsplit(bim, delims), function(line) {
+                        # Concatenate SNP name and minor allele (like --recodeA)
+                        return(paste0(line[2L], "_", line[5L]))
+                    })
+                }
             }
         }
     } else {
@@ -196,6 +218,10 @@ BEDMatrix <- setClass("BEDMatrix", slots = c(xptr = "externalptr", dims = "integ
 #' name as the [.bed](https://www.cog-genomics.org/plink2/formats#bed) file).
 #' If a positive integer, the .bim file is not read and `colnames` will be set
 #' to `NULL` and have to be provided manually.
+#' @param names_simple Simplifies the format of the rownames and columnames.
+#' If `FALSE` (the default) rownames are concatenated family and subject IDs,
+#' while colnames are concatenated SNP IDs and minor alleles.  If `TRUE`,
+#' rownames are subject IDs only and colnames are SNP IDs only.
 #' @return A [BEDMatrix-class] object.
 #' @example man/examples/initialize.R
 #' @seealso [BEDMatrix-package] to learn more about .bed files.

--- a/man/initialize-BEDMatrix-method.Rd
+++ b/man/initialize-BEDMatrix-method.Rd
@@ -5,7 +5,8 @@
 \alias{initialize,BEDMatrix-method}
 \title{Create a BEDMatrix Object from a PLINK .bed File.}
 \usage{
-\S4method{initialize}{BEDMatrix}(.Object, path, n = NULL, p = NULL)
+\S4method{initialize}{BEDMatrix}(.Object, path, n = NULL, p = NULL,
+  names_simple = FALSE)
 }
 \arguments{
 \item{.Object}{Internal, used by \code{\link[methods:initialize]{methods::initialize()}} generic.}
@@ -27,6 +28,11 @@ variants will be determined from the accompanying
 name as the \href{https://www.cog-genomics.org/plink2/formats#bed}{.bed} file).
 If a positive integer, the .bim file is not read and \code{colnames} will be set
 to \code{NULL} and have to be provided manually.}
+
+\item{names_simple}{Simplifies the format of the rownames and columnames.
+If \code{FALSE} (the default) rownames are concatenated family and subject IDs,
+while colnames are concatenated SNP IDs and minor alleles.  If \code{TRUE},
+rownames are subject IDs only and colnames are SNP IDs only.}
 }
 \value{
 A \linkS4class{BEDMatrix} object.


### PR DESCRIPTION
I added a `names_simple` option to BEDMatrix initialize.
I documented, repeated tests (all passed), upped version and added to news.

The option is FALSE by default (default behavior is the same as it used to be).  If TRUE, rownames are subject IDs only (without concatenating with family ID), and colnames are SNP IDs only (without concatenating with minor allele).  Personally I never use the default names, but sometimes I could not remove the undesired components by splitting with underscores, as some of my identifiers also have underscores.  The new names_simple=TRUE behavior is what I prefer for all my projects so I contributed this extension expecting others to want the same.